### PR TITLE
fix: dependencies stage postinstall can't find prisma/schema.prisma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /usr/src/app
 # pnpm-lock.yaml is lockfileVersion 9 (pnpm 9.x) — pin via corepack so the
 # install is reproducible regardless of whatever pnpm ships in the base image.
 RUN corepack enable && corepack prepare pnpm@9 --activate
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml prisma.config.ts ./
+# postinstall (prisma generate) needs the schema present — prisma.config.ts
+# points at prisma/schema.prisma, so the whole prisma/ dir has to exist
+# before `pnpm install` runs, not just after the later `COPY . .`.
+COPY prisma ./prisma
 
 # ---- Dependencies ----
 FROM base AS dependencies


### PR DESCRIPTION
The Render deploy of the previous hotfix still failed — one stage further than before. `base` only copied package.json/pnpm-lock.yaml before running `pnpm install` in the dependencies stage, but postinstall (`prisma generate`) needs prisma/schema.prisma (referenced via prisma.config.ts), which wasn't copied in until the later `COPY . .` in the build stage. Now copies prisma.config.ts and the whole prisma/ directory into the base stage before any install runs.

Verified end-to-end in an isolated directory outside Docker (no daemon available here): dependencies-stage install (with schema present) now runs postinstall successfully and produces generated/prisma/, the build stage produces dist/src/main.js, the production-stage prod-only install succeeds, and node dist/src/main.js against that boots the full Nest app up to the same "needs real env vars" boundary as before — the actual Docker build should now complete and the container should start correctly once real env vars are set on Render.


Claude-Session: https://claude.ai/code/session_01HcShdqQqNi5zin78L4df12