### PR TITLE
fix: pnpm-workspace.yaml missing packages field breaks pnpm 9 builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ allowBuilds:
   bcrypt: true
   prisma: true
   protobufjs: true
+packages: []


### PR DESCRIPTION
Render's build failed one stage further this time: `pnpm build` errored with "packages field missing or empty". pnpm-workspace.yaml already existed (for the allowBuilds config that whitelists which dependencies may run install scripts — bcrypt, prisma, @nestjs/core, etc., confirmed working in the Docker log), but had no `packages:` field. Its mere presence makes pnpm treat the project as a workspace root, and pnpm 9 (the version this Dockerfile pins via corepack) requires that field to be set even for a single-package "workspace" that only exists for this kind of root-level config — my local pnpm (11.1.1, newer, more lenient) didn't reproduce this, which is why the previous fix's local verification missed it. Added `packages: []` (no actual sub-packages).

This time verified with the *exact* pinned binary (`corepack pnpm@9`, not just whatever pnpm happened to be on PATH): full install (dev deps, postinstall/prisma generate succeeds), build (dist/src/main.js produced), prod-only install --ignore-scripts, and node dist/src/main.js booting to the same "needs real env vars" boundary as every prior verification pass — the actual gap between this and the previous (false-negative) local verification.


Claude-Session: https://claude.ai/code/session_01HcShdqQqNi5zin78L4df12