### PR TITLE
fix: pin package.json type to commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "type": "commonjs",
   "scripts": {
     "postinstall": "prisma generate",
     "build": "nest build",


### PR DESCRIPTION
Render's deployed container crashes at boot with "ReferenceError: exports is not defined in ES module scope" when loading dist/generated/prisma/client.js — despite that file being unambiguous CommonJS (require/exports, no import/export syntax) and tsconfig already targeting module: commonjs.

Could not reproduce the crash locally even pinning Node to 20.20.2 (matching node:20-alpine) and replaying the exact prod install/copy steps, so the precise trigger on Render's side is still unconfirmed. Setting "type": "commonjs" explicitly removes Node's module-type auto-detection entirely for this package (no more ambiguous-file heuristic to misfire on), which is the standard fix for this exact error class regardless of what specifically triggered it.


Claude-Session: https://claude.ai/code/session_01HcShdqQqNi5zin78L4df12