### PR TITLE
fix: copy tsconfig.json before pnpm install so prisma generate emits CJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ WORKDIR /usr/src/app
 # pnpm-lock.yaml is lockfileVersion 9 (pnpm 9.x) — pin via corepack so the
 # install is reproducible regardless of whatever pnpm ships in the base image.
 RUN corepack enable && corepack prepare pnpm@9 --activate
-COPY package.json pnpm-lock.yaml prisma.config.ts ./
+COPY package.json pnpm-lock.yaml prisma.config.ts tsconfig.json tsconfig.build.json ./
 # postinstall (prisma generate) needs the schema present — prisma.config.ts
 # points at prisma/schema.prisma, so the whole prisma/ dir has to exist
-# before `pnpm install` runs, not just after the later `COPY . .`.
+# before `pnpm install` runs, not just after the later `COPY . .`. tsconfig.json
+# also has to be present at generate-time: without it, Prisma's `prisma-client`
+# generator emits an ESM-style client (import.meta.url for __dirname) that
+# our commonjs-targeted tsc build then compiles into a runtime SyntaxError.
 COPY prisma ./prisma
 
 # ---- Dependencies ----


### PR DESCRIPTION
Root cause of the ESM SyntaxError finally confirmed, not guessed: the base stage only copied package.json/pnpm-lock.yaml/prisma.config.ts/prisma/ before running `pnpm install`, which triggers `prisma generate` via postinstall. Without tsconfig.json present at that point, Prisma's `prisma-client` generator emits an ESM-flavored client.ts that uses `import.meta.url` to resolve __dirname. Our tsc build (module: commonjs) compiles the surrounding import/export statements to require()/exports but leaves `import.meta` untouched, producing a file that's a hard SyntaxError under CommonJS at require() time — exactly the crash Render hit.

Verified by mirroring the Dockerfile's exact base-stage file set in a scratch dir: with only the pre-fix COPY list, `prisma generate` reproduces the import.meta output every time; adding tsconfig.json alone makes it disappear. Replayed the full base -> dependencies -> build -> prod-install sequence with the corrected COPY order and booted the compiled dist/src/main.js under Node 20.20.2 (matching node:20-alpine) — Nest initializes all modules and gets past the previous crash point entirely, now failing only on a missing env var (ADMIN_JWT_SECRET, expected with no .env in the scratch run).

The earlier "type": "commonjs" package.json change (previous commit) is unrelated to this bug but remains as a harmless, standard hardening against Node's module-type ambiguity.


Claude-Session: https://claude.ai/code/session_01HcShdqQqNi5zin78L4df12