### PR TITLE
feat: add professional experience module

### DIFF
--- a/prisma/migrations/20260827120000_add_professional_experiences/migration.sql
+++ b/prisma/migrations/20260827120000_add_professional_experiences/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "ProfessionalExperience" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "organizationName" TEXT NOT NULL,
+    "employmentType" TEXT,
+    "location" TEXT,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "isCurrent" BOOLEAN NOT NULL DEFAULT false,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfessionalExperience_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProfessionalExperience_userId_startDate_idx" ON "ProfessionalExperience"("userId", "startDate");
+
+-- AddForeignKey
+ALTER TABLE "ProfessionalExperience" ADD CONSTRAINT "ProfessionalExperience_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -228,6 +228,7 @@ model User {
   // ---------- Relations ----------
 
   professionalAccreditations ProfessionalAccreditation[]
+  professionalExperiences    ProfessionalExperience[]
 
   postsAuthored    Post[]    @relation("PostAuthor")
   commentsAuthored Comment[] @relation("CommentAuthor")
@@ -275,6 +276,24 @@ model ProfessionalAccreditation {
   issuingAuthority  String?
 
   @@index([userId])
+}
+
+model ProfessionalExperience {
+  id               String   @id @default(cuid())
+  userId           String
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title            String
+  organizationName String
+  employmentType   String?
+  location         String?
+  startDate        DateTime
+  endDate          DateTime?
+  isCurrent        Boolean  @default(false)
+  description      String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([userId, startDate])
 }
 
 // ---------- Social graph ----------

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { BlocksModule } from './blocks/blocks.module';
 import { PresenceModule } from './presence/presence.module';
 import { PresenceService } from './presence/presence.service';
 import { MessagesModule } from './messages/messages.module';
+import { ProfessionalExperiencesModule } from './professional-experiences/professional-experiences.module';
 
 @Module({
   imports: [
@@ -219,6 +220,7 @@ query GetAllUsers {
     BlocksModule,
     PresenceModule,
     MessagesModule,
+    ProfessionalExperiencesModule,
 
     // Cache Module (Redis with in-memory fallback)
     CacheModule,

--- a/src/professional-experiences/dto/create-professional-experience.input.ts
+++ b/src/professional-experiences/dto/create-professional-experience.input.ts
@@ -1,0 +1,46 @@
+import { Field, GraphQLISODateTime, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsDate, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+@InputType()
+export class CreateProfessionalExperienceInput {
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  organizationName: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  employmentType?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @Field(() => GraphQLISODateTime)
+  @Type(() => Date)
+  @IsDate()
+  startDate: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  endDate?: Date;
+
+  @Field({ defaultValue: false })
+  @IsBoolean()
+  isCurrent: boolean;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/professional-experiences/dto/update-professional-experience.input.ts
+++ b/src/professional-experiences/dto/update-professional-experience.input.ts
@@ -1,0 +1,21 @@
+import { Field, GraphQLISODateTime, InputType, PartialType } from '@nestjs/graphql';
+import { IsDate, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateProfessionalExperienceInput } from './create-professional-experience.input';
+
+@InputType()
+export class UpdateProfessionalExperienceInput extends PartialType(
+  CreateProfessionalExperienceInput,
+) {
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  startDate?: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  endDate?: Date;
+}

--- a/src/professional-experiences/models/professional-experience.model.ts
+++ b/src/professional-experiences/models/professional-experience.model.ts
@@ -1,0 +1,40 @@
+import { Field, GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('ProfessionalExperience')
+export class ProfessionalExperienceGQL {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID)
+  userId: string;
+
+  @Field()
+  title: string;
+
+  @Field()
+  organizationName: string;
+
+  @Field({ nullable: true })
+  employmentType?: string;
+
+  @Field({ nullable: true })
+  location?: string;
+
+  @Field(() => GraphQLISODateTime)
+  startDate: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  endDate?: Date;
+
+  @Field()
+  isCurrent: boolean;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updatedAt: Date;
+}

--- a/src/professional-experiences/professional-experiences.module.ts
+++ b/src/professional-experiences/professional-experiences.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ProfessionalExperiencesResolver } from './professional-experiences.resolver';
+import { ProfessionalExperiencesService } from './professional-experiences.service';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ProfessionalExperiencesResolver, ProfessionalExperiencesService],
+  exports: [ProfessionalExperiencesService],
+})
+export class ProfessionalExperiencesModule {}

--- a/src/professional-experiences/professional-experiences.resolver.ts
+++ b/src/professional-experiences/professional-experiences.resolver.ts
@@ -1,0 +1,62 @@
+import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { BetterAuthGuard } from '../auth/guards/better-auth.guard';
+import { CombinedAuthGuard } from '../auth/guards/combined-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { UserDocument } from '../users/schemas/users.schema';
+import { CreateProfessionalExperienceInput } from './dto/create-professional-experience.input';
+import { UpdateProfessionalExperienceInput } from './dto/update-professional-experience.input';
+import { ProfessionalExperienceGQL } from './models/professional-experience.model';
+import { ProfessionalExperiencesService } from './professional-experiences.service';
+
+@Resolver(() => ProfessionalExperienceGQL)
+export class ProfessionalExperiencesResolver {
+  constructor(
+    private readonly professionalExperiencesService: ProfessionalExperiencesService,
+  ) {}
+
+  @UseGuards(CombinedAuthGuard)
+  @Query(() => [ProfessionalExperienceGQL], {
+    name: 'getProfessionalExperiences',
+  })
+  getProfessionalExperiences(
+    @Args('userId', { type: () => ID }) userId: string,
+  ) {
+    return this.professionalExperiencesService.findByUserId(userId);
+  }
+
+  @UseGuards(BetterAuthGuard)
+  @Mutation(() => ProfessionalExperienceGQL, {
+    name: 'addProfessionalExperience',
+  })
+  addProfessionalExperience(
+    @Args('input') input: CreateProfessionalExperienceInput,
+    @CurrentUser() currentUser: UserDocument,
+  ) {
+    return this.professionalExperiencesService.create(currentUser.id, input);
+  }
+
+  @UseGuards(BetterAuthGuard)
+  @Mutation(() => ProfessionalExperienceGQL, {
+    name: 'updateProfessionalExperience',
+  })
+  updateProfessionalExperience(
+    @Args('id', { type: () => ID }) id: string,
+    @Args('input') input: UpdateProfessionalExperienceInput,
+    @CurrentUser() currentUser: UserDocument,
+  ) {
+    return this.professionalExperiencesService.update(currentUser.id, id, input);
+  }
+
+  @UseGuards(BetterAuthGuard)
+  @Mutation(() => Boolean, {
+    name: 'removeProfessionalExperience',
+  })
+  async removeProfessionalExperience(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() currentUser: UserDocument,
+  ): Promise<boolean> {
+    await this.professionalExperiencesService.remove(currentUser.id, id);
+    return true;
+  }
+}

--- a/src/professional-experiences/professional-experiences.service.ts
+++ b/src/professional-experiences/professional-experiences.service.ts
@@ -1,0 +1,105 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateProfessionalExperienceInput } from './dto/create-professional-experience.input';
+import { UpdateProfessionalExperienceInput } from './dto/update-professional-experience.input';
+
+@Injectable()
+export class ProfessionalExperiencesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByUserId(userId: string) {
+    return this.prisma.professionalExperience.findMany({
+      where: { userId },
+      orderBy: [{ isCurrent: 'desc' }, { startDate: 'desc' }, { createdAt: 'desc' }],
+    });
+  }
+
+  async create(userId: string, input: CreateProfessionalExperienceInput) {
+    this.assertDateRange(input.startDate, input.endDate, input.isCurrent);
+
+    return this.prisma.professionalExperience.create({
+      data: {
+        userId,
+        title: input.title.trim(),
+        organizationName: input.organizationName.trim(),
+        employmentType: input.employmentType?.trim() || null,
+        location: input.location?.trim() || null,
+        startDate: input.startDate,
+        endDate: input.isCurrent ? null : input.endDate,
+        isCurrent: input.isCurrent,
+        description: input.description?.trim() || null,
+      },
+    });
+  }
+
+  async update(
+    userId: string,
+    experienceId: string,
+    input: UpdateProfessionalExperienceInput,
+  ) {
+    const existing = await this.findOwnedExperience(userId, experienceId);
+    const nextStartDate = input.startDate ?? existing.startDate;
+    const nextIsCurrent = input.isCurrent ?? existing.isCurrent;
+    const nextEndDate = nextIsCurrent ? null : input.endDate ?? existing.endDate;
+
+    this.assertDateRange(nextStartDate, nextEndDate, nextIsCurrent);
+
+    return this.prisma.professionalExperience.update({
+      where: { id: experienceId },
+      data: {
+        ...(input.title !== undefined && { title: input.title.trim() }),
+        ...(input.organizationName !== undefined && {
+          organizationName: input.organizationName.trim(),
+        }),
+        ...(input.employmentType !== undefined && {
+          employmentType: input.employmentType?.trim() || null,
+        }),
+        ...(input.location !== undefined && {
+          location: input.location?.trim() || null,
+        }),
+        ...(input.startDate !== undefined && { startDate: input.startDate }),
+        ...(input.isCurrent !== undefined && { isCurrent: input.isCurrent }),
+        ...((input.endDate !== undefined || input.isCurrent !== undefined) && {
+          endDate: nextEndDate,
+        }),
+        ...(input.description !== undefined && {
+          description: input.description?.trim() || null,
+        }),
+      },
+    });
+  }
+
+  async remove(userId: string, experienceId: string): Promise<void> {
+    await this.findOwnedExperience(userId, experienceId);
+    await this.prisma.professionalExperience.delete({
+      where: { id: experienceId },
+    });
+  }
+
+  private async findOwnedExperience(userId: string, experienceId: string) {
+    const experience = await this.prisma.professionalExperience.findUnique({
+      where: { id: experienceId },
+    });
+
+    if (!experience) {
+      throw new NotFoundException('Professional experience not found.');
+    }
+
+    if (experience.userId !== userId) {
+      throw new ForbiddenException('You can only manage your own experiences.');
+    }
+
+    return experience;
+  }
+
+  private assertDateRange(startDate: Date, endDate?: Date | null, isCurrent = false) {
+    if (!isCurrent && endDate && endDate < startDate) {
+      throw new BadRequestException('endDate must be after startDate.');
+    }
+  }
+}

--- a/src/users/models/users.model.ts
+++ b/src/users/models/users.model.ts
@@ -6,6 +6,7 @@ import {
   registerEnumType,
   GraphQLISODateTime,
 } from '@nestjs/graphql';
+import { ProfessionalExperienceGQL } from '../../professional-experiences/models/professional-experience.model';
 
 export enum UserTypeGQL {
   INDIVIDUAL = 'INDIVIDUAL',
@@ -187,6 +188,12 @@ export abstract class User {
     description: 'Professional accreditation documents or details.',
   })
   professionalAccreditation?: ProfessionalAccreditationObject[];
+
+  @Field(() => [ProfessionalExperienceGQL], {
+    nullable: true,
+    description: 'Professional work history entries.',
+  })
+  professionalExperiences?: ProfessionalExperienceGQL[];
 
   @Field({ nullable: true })
   profilePicUrl?: string;

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -9,6 +9,7 @@ import { PubSubModule } from '../pubsub/pubsub.module';
 import { PostsModule } from 'src/posts/posts.module';
 import { FollowsModule } from '../follows/follows.module';
 import { BlocksModule } from '../blocks/blocks.module';
+import { ProfessionalExperiencesModule } from '../professional-experiences/professional-experiences.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { BlocksModule } from '../blocks/blocks.module';
     PubSubModule,
     FollowsModule,
     BlocksModule,
+    ProfessionalExperiencesModule,
   ],
   providers: [
     UsersResolver,

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -12,6 +12,7 @@ import {
 import { UsersService } from './users.service';
 import { FollowsService } from '../follows/follows.service';
 import { User } from './models/users.model'; // Import the base GraphQL User model/interface
+import { ProfessionalExperienceGQL } from '../professional-experiences/models/professional-experience.model';
 import { CreateUserInput } from './dto/create-user.input';
 import { UseGuards, BadRequestException, Inject } from '@nestjs/common';
 import { PubSub } from 'graphql-subscriptions';
@@ -34,6 +35,7 @@ import { FollowsUpdate } from './models/follower-count-update.model';
 import { PUB_SUB } from '../pubsub/pubsub.module';
 import { GqlWsAuthGuard } from 'src/auth/guards/gql-ws-auth.guard';
 import { ConnectionRequestsService } from './connection-requests.service';
+import { ProfessionalExperiencesService } from '../professional-experiences/professional-experiences.service';
 
 @Resolver(() => User) // Specify User as the base type this resolver handles
 export class UsersResolver {
@@ -41,6 +43,7 @@ export class UsersResolver {
     private readonly usersService: UsersService,
     private readonly followsService: FollowsService,
     private readonly connectionRequestsService: ConnectionRequestsService,
+    private readonly professionalExperiencesService: ProfessionalExperiencesService,
     @Inject(PUB_SUB) private readonly pubSub: PubSub,
   ) {}
 
@@ -436,5 +439,12 @@ export class UsersResolver {
     @CurrentUser() viewer: CurrentUserType,
   ): string[] | null {
     return this.canViewPrivateFields(user, viewer) ? user.fcmTokens : null;
+  }
+
+  @ResolveField('professionalExperiences', () => [ProfessionalExperienceGQL], {
+    nullable: true,
+  })
+  resolveProfessionalExperiences(@Parent() user: UserDocument) {
+    return this.professionalExperiencesService.findByUserId(user.id);
   }
 }


### PR DESCRIPTION
## Summary
- Add professional experiences API module, resolver, service, DTOs, and GraphQL model
- Expose user professional experiences on user profile data
- Add Prisma schema changes and migration for professional experiences

## Validation
- CI=true pnpm exec nest build